### PR TITLE
sci-electronics/fritzing: Fix libgit2 version check to allow building with versions >= 1.0

### DIFF
--- a/sci-electronics/fritzing/files/0.9.4_p498-update-libgit2-check.patch
+++ b/sci-electronics/fritzing/files/0.9.4_p498-update-libgit2-check.patch
@@ -1,0 +1,13 @@
+diff --git a/src/version/partschecker.cpp b/src/version/partschecker.cpp
+index 65daf76e..36300fe0 100644
+--- a/src/version/partschecker.cpp
++++ b/src/version/partschecker.cpp
+@@ -115,7 +115,7 @@
+	/**
+	 * Connect to the remote.
+	 */
+-#if LIBGIT2_VER_MINOR > 24
++#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR > 24)
+ 	error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL, NULL);
+ #elif LIBGIT2_VER_MINOR == 24
+ 	error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL);

--- a/sci-electronics/fritzing/fritzing-0.9.4_p498.ebuild
+++ b/sci-electronics/fritzing/fritzing-0.9.4_p498.ebuild
@@ -42,6 +42,7 @@ DOCS="README.md"
 
 PATCHES=(
 	"${FILESDIR}/disable-static-libgit2.patch"
+	"${FILESDIR}/0.9.4_p498-update-libgit2-check.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Until now, the check only considers the minor version number, so it breaks with versions greater than 0.99.

Submitted upstream at https://github.com/fritzing/fritzing-app/pull/3654